### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/springframework/data/crate/config/BeanNames.java
+++ b/src/main/java/org/springframework/data/crate/config/BeanNames.java
@@ -23,4 +23,6 @@ package org.springframework.data.crate.config;
 public abstract class BeanNames {
 	
 	public static final String SCHEMA_EXPORT_MANAGER = "cratePersistentEntitySchemaManager";
+
+	private BeanNames() {}
 }

--- a/src/main/java/org/springframework/data/crate/core/CrateErrorCodes.java
+++ b/src/main/java/org/springframework/data/crate/core/CrateErrorCodes.java
@@ -43,4 +43,6 @@ abstract class CrateErrorCodes {
 	public static final int TASKS_EXECUTION_FAILED = 5001;
 	public static final int SHARDS_NOT_AVAILABLE = 5002;
 	public static final int QUERY_FAILED_ON_SHARDS = 5003;
+
+	private CrateErrorCodes() {}
 }

--- a/src/main/java/org/springframework/data/crate/core/sql/CrateSQLUtil.java
+++ b/src/main/java/org/springframework/data/crate/core/sql/CrateSQLUtil.java
@@ -20,6 +20,8 @@ public class CrateSQLUtil {
 	private static final Pattern PATTERN = compile("\\['([^\\]]*)'\\]");
     private static final Pattern CRATE_SQL_PATTERN = compile("(.+?)(?:\\['([^\\]])*'\\])+");
 
+	private CrateSQLUtil() {}
+
 	public static String doubleQuote(String toQuote) {
 		
 		if(hasText(toQuote)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
